### PR TITLE
server: Check for the worker thread being joinable before joining.

### DIFF
--- a/src/zk/server/server.cpp
+++ b/src/zk/server/server.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<server> server::create(package_registry& registry)
 void server::shutdown(bool wait_for_stop)
 {
     _running = false;
-    if (wait_for_stop)
+    if (wait_for_stop && _worker.joinable())
         _worker.join();
 }
 

--- a/src/zk/server/server_tests.cpp
+++ b/src/zk/server/server_tests.cpp
@@ -79,4 +79,10 @@ GTEST_TEST(server_tests, start_stop)
     svr->shutdown();
 }
 
+GTEST_TEST(server_tests, shutdown_and_wait)
+{
+    auto svr = server::create(test_package_registry::instance());
+    svr->shutdown(true);
+}
+
 }


### PR DESCRIPTION
Fixes issue #56