### PR TITLE
server: Do not spin in `server::run_process`.

### DIFF
--- a/src/zk/server/detail/event_handle.cpp
+++ b/src/zk/server/detail/event_handle.cpp
@@ -1,0 +1,49 @@
+#include "event_handle.hpp"
+#include "close.hpp"
+
+#include <cerrno>
+#include <cstdint>
+#include <system_error>
+
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+namespace zk::server::detail
+{
+
+event_handle::event_handle() :
+        _fd(::eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK))
+{ }
+
+event_handle::~event_handle() noexcept
+{
+    close();
+}
+
+void event_handle::close() noexcept
+{
+    if (_fd != -1)
+    {
+        detail::close(_fd);
+        _fd = -1;
+    }
+}
+
+void event_handle::notify_one()
+{
+    std::uint64_t x = 1;
+    if (::write(_fd, &x, sizeof x) == -1 && errno != EAGAIN)
+        throw std::system_error(errno, std::system_category(), "event_handle::notify_one()");
+}
+
+bool event_handle::try_wait()
+{
+    std::uint64_t burn;
+    if (::read(_fd, &burn, sizeof burn) == -1)
+        return errno == EAGAIN ? false
+                               : throw std::system_error(errno, std::system_category(), "event_handle::try_wait()");
+    else
+        return true;
+}
+
+}

--- a/src/zk/server/detail/event_handle.hpp
+++ b/src/zk/server/detail/event_handle.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <zk/config.hpp>
+
+namespace zk::server::detail
+{
+
+class event_handle final
+{
+public:
+    using native_handle_type = int;
+
+public:
+    explicit event_handle();
+
+    event_handle(const event_handle&) = delete;
+
+    event_handle& operator=(const event_handle&) = delete;
+
+    ~event_handle() noexcept;
+
+    /// Close this event for future signalling. This is automatically called from the destructor.
+    void close() noexcept;
+
+    /// Signal this handle that something has happened.
+    void notify_one();
+
+    /// Attempt to wait for this handle to be signalled, but do not block.
+    ///
+    /// \returns \c true if we successfully waited for a signal (and consumed it); \c false if this handle was not
+    ///  signalled.
+    bool try_wait();
+
+    /// Get the file descriptor backing this handle. This is generally only used when interacting with the kernel and
+    /// should be avoided in regular use.
+    native_handle_type native_handle() { return _fd; }
+
+private:
+    native_handle_type _fd;
+};
+
+}

--- a/src/zk/server/detail/subprocess.hpp
+++ b/src/zk/server/detail/subprocess.hpp
@@ -2,6 +2,7 @@
 
 #include <zk/config.hpp>
 
+#include <chrono>
 #include <cstddef>
 #include <iosfwd>
 #include <string>
@@ -12,12 +13,13 @@
 namespace zk::server::detail
 {
 
-/** Represents an owned subprocess. **/
+/// Represents an owned subprocess.
 class subprocess
 {
 public:
-    using handle = int;
+    using handle        = int;
     using argument_list = std::vector<std::string>;
+    using duration_type = std::chrono::seconds;
 
 public:
     explicit subprocess(std::string program_name, argument_list args = argument_list());
@@ -27,17 +29,19 @@ public:
 
     ~subprocess() noexcept;
 
-    /** Send a signal to this subprocess.
-     *
-     *  \param whole_group Should the entire process group be signalled or just the root process?
-     *  \returns \c true if the signal likely reached the subprocess; \c false if it might not have (this can happen if
-     *   the subprocess has already terminated).
-    **/
-    bool signal(int sig_val, bool whole_group = false);
+    /// Send a signal to this subprocess.
+    ///
+    /// \returns \c true if the signal likely reached the subprocess; \c false if it might not have (this can happen if
+    ///  the subprocess has already terminated).
+    bool signal(int sig_val);
 
     pipe& stdin()  noexcept { return _stdin; }
     pipe& stdout() noexcept { return _stdout; }
     pipe& stderr() noexcept { return _stderr; }
+
+    /// Terminate the process if it is still running. In the first attempt to terminate, \c SIGTERM is used. If the
+    /// process has not terminated before \a time_to_abort has passed, the process is signalled again with \c SIGABRT.
+    void terminate(duration_type time_to_abort = std::chrono::seconds(1U)) noexcept;
 
 private:
     std::string _program_name;

--- a/src/zk/server/server.hpp
+++ b/src/zk/server/server.hpp
@@ -11,6 +11,13 @@
 namespace zk::server
 {
 
+namespace detail
+{
+
+class event_handle;
+
+}
+
 /// \defgroup Server
 /// Control a ZooKeeper \ref server process.
 /// \{
@@ -53,8 +60,9 @@ private:
     void run_process(const classpath&, const configuration&);
 
 private:
-    std::atomic<bool> _running;
-    std::thread       _worker;
+    std::atomic<bool>                     _running;
+    std::unique_ptr<detail::event_handle> _shutdown_event;
+    std::thread                           _worker;
 
     // NOTE: The configuration is NOT stored in the server object. This is because configuration can be changed by the
     // ZK process in cases like ensemble reconfiguration. It is the job of run_process to deal with this.


### PR DESCRIPTION
Creates a helper class for `::eventfd` and uses `::select` on STDOUT and STDERR
of the subprocess and the shutdown event instead of spinning. It also drains the
STDOUT and STDERR pipes after the process is fully terminated and reaped, so the
last bits of subprocess output will no longer be lost.

This also _might_ fix some of the server-not-dying issues I have seen
intermittenly due to a misuse of POSIX `::kill`. Unclear, though...

Fixes issue #82.