### PR TITLE
Use CMAKE_INSTALL_PREFIX instead of hardcoded /usr/local install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,9 +250,9 @@ if(ZKPP_PACKAGE_SYSTEM)
 
         add_custom_target("lib${package_name}.deb"
                           BYPRODUCTS "install/lib${package_name}${PROJECT_SO_VERSION}.deb"
-                          COMMAND rm -rf "install/lib${package_name}${PROJECT_SO_VERSION}/usr/local/lib"
-                          COMMAND mkdir -p "install/lib${package_name}${PROJECT_SO_VERSION}/usr/local/lib"
-                          COMMAND cp "$<TARGET_FILE:${module}>" "install/lib${package_name}${PROJECT_SO_VERSION}/usr/local/lib"
+                          COMMAND rm -rf "install/lib${package_name}${PROJECT_SO_VERSION}${CMAKE_INSTALL_PREFIX}/lib"
+                          COMMAND mkdir -p "install/lib${package_name}${PROJECT_SO_VERSION}${CMAKE_INSTALL_PREFIX}/lib"
+                          COMMAND cp "$<TARGET_FILE:${module}>" "install/lib${package_name}${PROJECT_SO_VERSION}${CMAKE_INSTALL_PREFIX}/lib"
                           COMMAND dpkg --build "install/lib${package_name}${PROJECT_SO_VERSION}"
                           DEPENDS
                             "${CMAKE_CURRENT_BINARY_DIR}/install/lib${package_name}${PROJECT_SO_VERSION}/DEBIAN/control"
@@ -263,7 +263,7 @@ if(ZKPP_PACKAGE_SYSTEM)
 
       if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/install/deb/lib${package_name}-dev")
         message(STATUS "    lib${package_name}-dev")
-        set(staging_dir "install/lib${package_name}${PROJECT_SO_VERSION}-dev/usr/local/include/${header_path}")
+        set(staging_dir "install/lib${package_name}${PROJECT_SO_VERSION}-dev${CMAKE_INSTALL_PREFIX}/include/${header_path}")
         configure_file("${CMAKE_CURRENT_SOURCE_DIR}/install/deb/lib${package_name}-dev/control.in"
                        "${CMAKE_CURRENT_BINARY_DIR}/install/lib${package_name}${PROJECT_SO_VERSION}-dev/DEBIAN/control"
                        @ONLY IMMEDIATE

--- a/install/deb/libzkpp-server/postinst.in
+++ b/install/deb/libzkpp-server/postinst.in
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 
-update-alternatives --install /usr/local/lib/libzkpp-server.so libzkpp-server /usr/local/lib/libzkpp-server.so.@PROJECT_SO_VERSION@ 10
+update-alternatives --install @CMAKE_INSTALL_PREFIX@/lib/libzkpp-server.so libzkpp-server @CMAKE_INSTALL_PREFIX@/lib/libzkpp-server.so.@PROJECT_SO_VERSION@ 10

--- a/install/deb/libzkpp/postinst.in
+++ b/install/deb/libzkpp/postinst.in
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 
-update-alternatives --install /usr/local/lib/libzkpp.so libzkpp /usr/local/lib/libzkpp.so.@PROJECT_SO_VERSION@ 10
+update-alternatives --install @CMAKE_INSTALL_PREFIX@/lib/libzkpp.so libzkpp @CMAKE_INSTALL_PREFIX@/lib/libzkpp.so.@PROJECT_SO_VERSION@ 10


### PR DESCRIPTION
Hey,

CMake has CMAKE_INSTALL_PREFIX variable which defaults `/usr/local`, but is configurable during cmake configuration stage. I think it would be nice to respect it.

This PR makes deb packages which installs all the files according to CMAKE_INSTALL_PREFIX. The default behaviour is unchanged, because CMAKE_INSTALL_PREFIX defaults to the same `/usr/local` previously hardcoded.