### PR TITLE
remove zk::client::client default constructor declaration as it is no…

### DIFF
--- a/src/zk/client.hpp
+++ b/src/zk/client.hpp
@@ -25,9 +25,6 @@ namespace zk
 class client final
 {
 public:
-    /// Create a non-connected client. All operations will fail.
-    client() noexcept;
-
     /// Create a client connected to the cluster specified by \a params.
     explicit client(const connection_params& params);
 


### PR DESCRIPTION
Hey,

zk::client::client default constructor was declared, but never defined. This might cause a bit confusing "undefined reference" errors during linking.

I was also thinking about defaulting this constructor (`= default`), but then any called method will try to dereference empty shared_ptr (`_conn`), so in my opinion, it is better just to delete the declaration.