### PR TITLE
Allow use of boost::future as zk::future

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ configuration_setting(NAME    FUTURE
                       OPTIONS
                         STD
                         STD_EXPERIMENTAL
+                        BOOST
                         CUSTOM
                      )
 
@@ -88,8 +89,19 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 ################################################################################
 
 find_library(zookeeper_LIBRARIES zookeeper_mt)
+set(ZKPP_LIB_DEPENDENCIES ${ZKPP_LIB_DEPENDENCIES} ${zookeeper_LIBRARIES})
 
 include_directories("${PROJECT_SOURCE_DIR}/src")
+
+if (ZKPP_BUILD_SETTING_FUTURE STREQUAL "BOOST")
+    find_package(Boost
+                 1.52.0
+                 REQUIRED
+                 thread)
+    set(ZKPP_LIB_DEPENDENCIES ${ZKPP_LIB_DEPENDENCIES} ${Boost_LIBRARIES})
+endif()
+
+
 
 ################################################################################
 # GTest                                                                        #
@@ -146,8 +158,8 @@ build_module(NAME zkpp
              PATH src/zk
              NO_RECURSE
              LINK_LIBRARIES
-               ${zookeeper_LIBRARIES}
-            )
+             ${ZKPP_LIB_DEPENDENCIES}
+             )
 
 build_module(NAME zkpp-server
              PATH src/zk/server

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Ultimately, the usage looks like this (assuming you have a ZooKeeper server runn
 
     /** All result types are printable for debugging purposes. **/
     template <typename T>
-    void print_thing(const std::future<T>& result)
+    void print_thing(const zk::future<T>& result)
     {
         try
         {

--- a/src/zk/client.cpp
+++ b/src/zk/client.cpp
@@ -46,9 +46,9 @@ future<client> client::connect(connection_params conn_params)
         else
         {
             // TODO: Test if future::then can be relied on and use that instead of std::async
-            return std::async
+            return zk::async
                    (
-                       std::launch::async,
+                       zk::launch::async,
                        [state_change_fut = std::move(state_change_fut), conn = std::move(conn)] () mutable -> client
                        {
                          state s(state_change_fut.get());

--- a/src/zk/client.cpp
+++ b/src/zk/client.cpp
@@ -2,6 +2,7 @@
 #include "acl.hpp"
 #include "connection.hpp"
 #include "multi.hpp"
+#include "exceptions.hpp"
 
 #include <sstream>
 #include <ostream>
@@ -54,7 +55,7 @@ future<client> client::connect(connection_params conn_params)
                          if (s == state::connected)
                             return client(conn);
                          else
-                             throw std::runtime_error(std::string("Unexpected state: ") + to_string(s));
+                            zk::throw_exception(std::runtime_error(std::string("Unexpected state: ") + to_string(s)));
                        }
                    );
         }
@@ -62,7 +63,7 @@ future<client> client::connect(connection_params conn_params)
     catch (...)
     {
         promise<client> p;
-        p.set_exception(std::current_exception());
+        p.set_exception(zk::current_exception());
         return p.get_future();
     }
 }

--- a/src/zk/connection_zk.cpp
+++ b/src/zk/connection_zk.cpp
@@ -990,7 +990,7 @@ future<void> connection_zk::load_fence()
                 prom->set_exception(get_exception_ptr_of(rc));
         };
 
-    auto ppromise = std::make_unique<std::promise<void>>();
+    auto ppromise = std::make_unique<zk::promise<void>>();
     auto rc = error_code_from_raw(::zoo_async(_handle, "/", callback, ppromise.get()));
     if (rc == error_code::ok)
     {

--- a/src/zk/connection_zk.cpp
+++ b/src/zk/connection_zk.cpp
@@ -1,4 +1,5 @@
 #include "connection_zk.hpp"
+#include "exceptions.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -168,7 +169,7 @@ connection_zk::connection_zk(const connection_params& params) :
         _handle(nullptr)
 {
     if (params.connection_schema() != "zk")
-        throw std::invalid_argument(std::string("Invalid connection string \"") + to_string(params) + "\"");
+        zk::throw_exception(std::invalid_argument(std::string("Invalid connection string \"") + to_string(params) + "\""));
 
     auto conn_string = [&] ()
                        {
@@ -254,7 +255,7 @@ public:
         watcher::deliver_event(std::move(ev));
     }
 
-    void deliver_data(optional<TResult> data, std::exception_ptr ex_ptr)
+    void deliver_data(optional<TResult> data, zk::exception_ptr ex_ptr)
     {
         if (!_data_delivered.exchange(true, std::memory_order_relaxed))
         {
@@ -378,7 +379,7 @@ public:
             self.deliver_data(watch_result(get_result(buffer(data, data + data_sz), stat_from_raw(*pstat)),
                                            self.get_event_future()
                                           ),
-                              std::exception_ptr()
+                              zk::exception_ptr()
                              );
         }
         else
@@ -431,7 +432,7 @@ future<get_children_result> connection_zk::get_children(string_view path)
             }
             catch (...)
             {
-                prom->set_exception(std::current_exception());
+                prom->set_exception(zk::current_exception());
             }
         };
 
@@ -482,12 +483,12 @@ public:
                                                                        ),
                                                     self.get_event_future()
                                                    ),
-                              std::exception_ptr()
+                              zk::exception_ptr()
                              );
         }
         catch (...)
         {
-            self.deliver_data(nullopt, std::current_exception());
+            self.deliver_data(nullopt, zk::current_exception());
         }
 
     }
@@ -561,13 +562,13 @@ public:
         if (rc == error_code::ok)
         {
             self.deliver_data(watch_exists_result(exists_result(stat_from_raw(*stat_in)), self.get_event_future()),
-                              std::exception_ptr()
+                              zk::exception_ptr()
                              );
         }
         else if (rc == error_code::no_entry)
         {
             self.deliver_data(watch_exists_result(exists_result(nullopt), self.get_event_future()),
-                              std::exception_ptr()
+                              zk::exception_ptr()
                              );
         }
         else
@@ -853,12 +854,12 @@ struct connection_zk_commit_completer
                 auto iter = std::partition_point(raw_results.begin(), raw_results.end(),
                                                  [] (auto res) { return res.err == 0; }
                                                 );
-                throw transaction_failed(rc, std::size_t(std::distance(raw_results.begin(), iter)));
+                zk::throw_exception(transaction_failed(rc, std::size_t(std::distance(raw_results.begin(), iter))));
             }
         }
         catch (...)
         {
-            prom.set_exception(std::current_exception());
+            prom.set_exception(zk::current_exception());
         }
     }
 };
@@ -944,9 +945,9 @@ future<multi_result> connection_zk::commit(multi_op&& txn_in)
                 default:
                 {
                     using std::to_string;
-                    throw std::invalid_argument("Invalid op_type at index=" + to_string(idx) + ": "
+                    zk::throw_exception(std::invalid_argument("Invalid op_type at index=" + to_string(idx) + ": "
                                                 + to_string(src_op.type())
-                                               );
+                                               ));
                 }
             }
         }
@@ -972,7 +973,7 @@ future<multi_result> connection_zk::commit(multi_op&& txn_in)
     }
     catch (...)
     {
-        pcompleter->prom.set_exception(std::current_exception());
+        pcompleter->prom.set_exception(zk::current_exception());
         return pcompleter->prom.get_future();
     }
 }

--- a/src/zk/error.cpp
+++ b/src/zk/error.cpp
@@ -1,4 +1,5 @@
 #include "error.hpp"
+#include "exceptions.hpp"
 
 #include <sstream>
 #include <ostream>
@@ -32,30 +33,30 @@ void throw_error(error_code code)
 {
     switch (code)
     {
-    case error_code::connection_loss:               throw connection_loss();
-    case error_code::marshalling_error:             throw marshalling_error();
-    case error_code::not_implemented:               throw not_implemented("unspecified");
-    case error_code::invalid_arguments:             throw invalid_arguments();
-    case error_code::new_configuration_no_quorum:   throw new_configuration_no_quorum();
-    case error_code::reconfiguration_in_progress:   throw reconfiguration_in_progress();
-    case error_code::no_entry:                      throw no_entry();
-    case error_code::not_authorized:                throw not_authorized();
-    case error_code::version_mismatch:              throw version_mismatch();
-    case error_code::no_children_for_ephemerals:    throw no_children_for_ephemerals();
-    case error_code::entry_exists:                  throw entry_exists();
-    case error_code::not_empty:                     throw not_empty();
-    case error_code::session_expired:               throw session_expired();
-    case error_code::authentication_failed:         throw authentication_failed();
-    case error_code::closed:                        throw closed();
-    case error_code::read_only_connection:          throw read_only_connection();
-    case error_code::ephemeral_on_local_session:    throw ephemeral_on_local_session();
-    case error_code::reconfiguration_disabled:      throw reconfiguration_disabled();
-    case error_code::transaction_failed:            throw transaction_failed(error_code::transaction_failed, 0U);
-    default:                                        throw error(code, "unknown");
+    case error_code::connection_loss:               zk::throw_exception( connection_loss() );
+    case error_code::marshalling_error:             zk::throw_exception( marshalling_error() );
+    case error_code::not_implemented:               zk::throw_exception( not_implemented("unspecified") );
+    case error_code::invalid_arguments:             zk::throw_exception( invalid_arguments() );
+    case error_code::new_configuration_no_quorum:   zk::throw_exception( new_configuration_no_quorum() );
+    case error_code::reconfiguration_in_progress:   zk::throw_exception( reconfiguration_in_progress() );
+    case error_code::no_entry:                      zk::throw_exception( no_entry() );
+    case error_code::not_authorized:                zk::throw_exception( not_authorized() );
+    case error_code::version_mismatch:              zk::throw_exception( version_mismatch() );
+    case error_code::no_children_for_ephemerals:    zk::throw_exception( no_children_for_ephemerals() );
+    case error_code::entry_exists:                  zk::throw_exception( entry_exists() );
+    case error_code::not_empty:                     zk::throw_exception( not_empty() );
+    case error_code::session_expired:               zk::throw_exception( session_expired() );
+    case error_code::authentication_failed:         zk::throw_exception( authentication_failed() );
+    case error_code::closed:                        zk::throw_exception( closed() );
+    case error_code::read_only_connection:          zk::throw_exception( read_only_connection() );
+    case error_code::ephemeral_on_local_session:    zk::throw_exception( ephemeral_on_local_session() );
+    case error_code::reconfiguration_disabled:      zk::throw_exception( reconfiguration_disabled() );
+    case error_code::transaction_failed:            zk::throw_exception( transaction_failed(error_code::transaction_failed, 0U) );
+    default:                                        zk::throw_exception( error(code, "unknown") );
     }
 }
 
-std::exception_ptr get_exception_ptr_of(error_code code)
+zk::exception_ptr get_exception_ptr_of(error_code code)
 {
     try
     {
@@ -63,7 +64,7 @@ std::exception_ptr get_exception_ptr_of(error_code code)
     }
     catch (...)
     {
-        return std::current_exception();
+        return zk::current_exception();
     }
 }
 

--- a/src/zk/error.hpp
+++ b/src/zk/error.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <zk/config.hpp>
+#include "exceptions.hpp"
 
 #include <iosfwd>
 #include <string>
@@ -91,10 +92,10 @@ std::string to_string(const error_code&);
 [[noreturn]]
 void throw_error(error_code code);
 
-/// Get an \c std::exception_ptr containing an exception with the proper type for the given \a code.
+/// Get an \c zk::exception_ptr containing an exception with the proper type for the given \a code.
 ///
 /// \see throw_error
-std::exception_ptr get_exception_ptr_of(error_code code);
+zk::exception_ptr get_exception_ptr_of(error_code code);
 
 /// Get the \c std::error_category capable of describing ZooKeeper-provided error codes.
 ///

--- a/src/zk/error.hpp
+++ b/src/zk/error.hpp
@@ -138,7 +138,7 @@ public:
 /// the client can experience a \ref connection_loss before the server replies with OK.
 ///
 /// \see session_expired
-class connection_loss final :
+class connection_loss:
         public transport_error
 {
 public:
@@ -153,7 +153,7 @@ public:
 /// <a href="https://zookeeper.apache.org/doc/r3.4.10/zookeeperAdmin.html">ZooKeeper Administrator's Guide</a> for more
 /// information and a stern warning). Another possible cause is the system running out of memory, but due to overcommit,
 /// OOM issues rarely manifest so cleanly.
-class marshalling_error final :
+class marshalling_error:
         public transport_error
 {
 public:
@@ -164,7 +164,7 @@ public:
 
 /// Operation was attempted that was not implemented. If you happen to be writing a \ref connection implementation, you
 /// are encouraged to raise this error in cases where you have not implemented an operation.
-class not_implemented final :
+class not_implemented:
         public error
 {
 public:
@@ -192,7 +192,7 @@ public:
 /// credentials to function.
 ///
 /// \see acl_rule
-class authentication_failed final :
+class authentication_failed:
         public invalid_arguments
 {
 public:
@@ -216,7 +216,7 @@ public:
 /// Raised when attempting an ensemble reconfiguration, but the proposed new ensemble would not be able to form quorum.
 /// This happens when not enough time has passed for potential new servers to sync with the leader. If the proposed new
 /// ensemble is up and running, the solution is usually to simply wait longer and attempt reconfiguration later.
-class new_configuration_no_quorum final :
+class new_configuration_no_quorum:
         public invalid_ensemble_state
 {
 public:
@@ -227,7 +227,7 @@ public:
 
 /// An attempt was made to reconfigure the ensemble, but there is already a reconfiguration in progress. Concurrent
 /// reconfiguration is not supported.
-class reconfiguration_in_progress final :
+class reconfiguration_in_progress:
         public invalid_ensemble_state
 {
 public:
@@ -237,7 +237,7 @@ public:
 };
 
 /// The ensemble does not support reconfiguration.
-class reconfiguration_disabled final :
+class reconfiguration_disabled:
         public invalid_ensemble_state
 {
 public:
@@ -267,7 +267,7 @@ public:
 /// of resuming a session can happen even in cases of quorum loss, as session expiration requires a leader in order to
 /// proceed, so a client reconnecting soon enough after the ensemble forms quorum and elects a leader will resume the
 /// session, even if the quorum has been lost for days.
-class session_expired final :
+class session_expired:
         public invalid_connection_state
 {
 public:
@@ -277,7 +277,7 @@ public:
 };
 
 /// An attempt was made to read or write to a ZNode when the connection does not have permission to do.
-class not_authorized final :
+class not_authorized:
         public invalid_connection_state
 {
 public:
@@ -288,7 +288,7 @@ public:
 
 /// The connection is closed. This exception is delivered for all unfilled operations and watches when the connection is
 /// closing.
-class closed final :
+class closed:
         public invalid_connection_state
 {
 public:
@@ -300,7 +300,7 @@ public:
 /// An attempt was made to create an ephemeral entry, but the connection has a local session.
 ///
 /// \see connection_params::local
-class ephemeral_on_local_session final :
+class ephemeral_on_local_session:
         public invalid_connection_state
 {
 public:
@@ -312,7 +312,7 @@ public:
 /// A write operation was attempted on a read-only connection.
 ///
 /// \see connection_params::read_only
-class read_only_connection final :
+class read_only_connection :
         public invalid_connection_state
 {
 public:
@@ -333,7 +333,7 @@ public:
 };
 
 /// Thrown from read operations when attempting to read a ZNode that does not exist.
-class no_entry final :
+class no_entry :
         public check_failed
 {
 public:
@@ -343,7 +343,7 @@ public:
 };
 
 /// Thrown when attempting to create a ZNode, but one already exists at the specified path.
-class entry_exists final :
+class entry_exists :
         public check_failed
 {
 public:
@@ -353,7 +353,7 @@ public:
 };
 
 /// Thrown when attempting to erase a ZNode that has children.
-class not_empty final :
+class not_empty :
         public check_failed
 {
 public:
@@ -364,7 +364,7 @@ public:
 
 /// Thrown from modification operations when a version check is specified and the value in the database does not match
 /// the expected.
-class version_mismatch final :
+class version_mismatch :
         public check_failed
 {
 public:
@@ -374,7 +374,7 @@ public:
 };
 
 /// Ephemeral ZNodes cannot have children.
-class no_children_for_ephemerals final :
+class no_children_for_ephemerals :
         public check_failed
 {
 public:
@@ -385,7 +385,7 @@ public:
 
 /// Thrown from \ref client::commit when a transaction cannot be committed to the system. Check the
 /// \ref underlying_cause to see the specific error and \ref failed_op_index to see what operation failed.
-class transaction_failed final :
+class transaction_failed :
         public check_failed
 {
 public:

--- a/src/zk/exceptions.cpp
+++ b/src/zk/exceptions.cpp
@@ -1,0 +1,15 @@
+#include "exceptions.hpp"
+
+namespace zk
+{
+
+exception_ptr current_exception() noexcept
+{
+#if ZKPP_FUTURE_USE_BOOST
+    return boost::current_exception();
+#else
+    return std::current_exception();
+#endif
+}
+
+}

--- a/src/zk/exceptions.hpp
+++ b/src/zk/exceptions.hpp
@@ -15,6 +15,11 @@
 
 namespace zk
 {
+
+/// \addtogroup Client
+/// \{
+
+
 #if ZKPP_FUTURE_USE_BOOST
 
 using exception_ptr = boost::exception_ptr;
@@ -39,6 +44,8 @@ template<typename T>
 }
 
 #endif
+
+/// \}
 
 }
 

--- a/src/zk/exceptions.hpp
+++ b/src/zk/exceptions.hpp
@@ -30,7 +30,7 @@ template<typename T>
 #else
 
 using exception_ptr = std::exception_ptr;
-exception_ptr current_exception() noexcept
+exception_ptr current_exception() noexcept;
 
 template<typename T>
 [[noreturn]] inline void throw_exception(T const & e)

--- a/src/zk/exceptions.hpp
+++ b/src/zk/exceptions.hpp
@@ -1,0 +1,44 @@
+/** \file
+ *  Controls the throwing of exceptions and import of \c exception_ptr types and \c current_exception implementation.
+ *  These are probably \c std::exception_ptr and \c std::current_exception(), but if boost future is used it will be
+ *  boost's implementation.
+**/
+#pragma once
+
+#include <zk/future.hpp>
+
+#if ZKPP_FUTURE_USE_BOOST
+#include <boost/exception_ptr.hpp>
+#else
+#include <exception>
+#endif
+
+namespace zk
+{
+#if ZKPP_FUTURE_USE_BOOST
+
+using exception_ptr = boost::exception_ptr;
+exception_ptr current_exception() noexcept;
+
+template<typename T>
+[[noreturn]] inline void throw_exception(T const & e)
+{
+	throw boost::enable_current_exception(e);
+}
+
+
+#else
+
+using exception_ptr = std::exception_ptr;
+exception_ptr current_exception() noexcept
+
+template<typename T>
+[[noreturn]] inline void throw_exception(T const & e)
+{
+	throw e;
+}
+
+#endif
+
+}
+

--- a/src/zk/future.hpp
+++ b/src/zk/future.hpp
@@ -40,7 +40,7 @@
  *  The template to use for \c zk::async. This should be highly related to \c ZKPP_FUTURE_TEMPLATE and usually mapped
  *  to std::async or boost::async.
  *
- *  \def ZKPP_LAUNCH_ENUM_
+ *  \def ZKPP_LAUNCH_ENUM
  *  The enum to use for \c zk::async launch policy. This should be highly related to \c ZKPP_FUTURE_TEMPLATE and usually mapped
  *  to std::launch::async or boost::launch::async.
  *

--- a/src/zk/future.hpp
+++ b/src/zk/future.hpp
@@ -18,7 +18,7 @@
 #   define ZKPP_FUTURE_USE_STD_EXPERIMENTAL 0
 #endif
 
-/** \def ZKPP_FUTURE_USE_BOOST_
+/** \def ZKPP_FUTURE_USE_BOOST
  *  Set this to 1 to use \c boost::future and \c boost::promise as the backing types for
  *  \c zk::future and \c zk::promise.
 **/

--- a/src/zk/future.hpp
+++ b/src/zk/future.hpp
@@ -18,6 +18,14 @@
 #   define ZKPP_FUTURE_USE_STD_EXPERIMENTAL 0
 #endif
 
+/** \def ZKPP_FUTURE_USE_BOOST_
+ *  Set this to 1 to use \c boost::future and \c boost::promise as the backing types for
+ *  \c zk::future and \c zk::promise.
+**/
+#ifndef ZKPP_FUTURE_USE_BOOST
+#   define ZKPP_FUTURE_USE_BOOST 0
+#endif
+
 /** \def ZKPP_FUTURE_USE_CUSTOM
  *  Set this to 1 to use custom definitions of \c zk::future and \c zk::promise. If this is set, you must also set
  *  \c ZKPP_FUTURE_TEMPLATE, \c ZKPP_PROMISE_TEMPLATE, and \c ZKPP_FUTURE_INCLUDE.
@@ -41,7 +49,7 @@
  *  This is the default behavior.
 **/
 #ifndef ZKPP_FUTURE_USE_STD
-#   if ZKPP_FUTURE_USE_STD_EXPERIMENTAL || ZKPP_FUTURE_USE_CUSTOM
+#   if ZKPP_FUTURE_USE_BOOST || ZKPP_FUTURE_USE_STD_EXPERIMENTAL || ZKPP_FUTURE_USE_CUSTOM
 #       define ZKPP_FUTURE_USE_STD 0
 #   else
 #       define ZKPP_FUTURE_USE_STD 1
@@ -56,6 +64,13 @@
 #   define ZKPP_FUTURE_INCLUDE   <experimental/future>
 #   define ZKPP_FUTURE_TEMPLATE  std::experimental::future
 #   define ZKPP_PROMISE_TEMPLATE std::experimental::promise
+#elif ZKPP_FUTURE_USE_BOOST
+#   define BOOST_THREAD_PROVIDES_FUTURE
+#   define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
+#   define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
+#   define ZKPP_FUTURE_INCLUDE   <boost/thread/future.hpp>
+#   define ZKPP_FUTURE_TEMPLATE  boost::future
+#   define ZKPP_PROMISE_TEMPLATE boost::promise
 #elif ZKPP_FUTURE_USE_CUSTOM
 #   if !defined ZKPP_FUTURE_TEMPLATE || !defined ZKPP_PROMISE_TEMPLATE || !defined ZKPP_FUTURE_INCLUDE
 #       error "When ZKPP_FUTURE_USE_CUSTOM is set, you must also define ZKPP_FUTURE_TEMPLATE, ZKPP_PROMISE_TEMPLATE,"

--- a/src/zk/future.hpp
+++ b/src/zk/future.hpp
@@ -36,6 +36,14 @@
  *  \def ZKPP_PROMISE_TEMPLATE
  *  The template to use for \c zk::promise. This should be highly related to \c ZKPP_FUTURE_TEMPLATE
  *
+ *  \def ZKPP_ASYNC_TEMPLATE
+ *  The template to use for \c zk::async. This should be highly related to \c ZKPP_FUTURE_TEMPLATE and usually mapped
+ *  to std::async or boost::async.
+ *
+ *  \def ZKPP_LAUNCH_ENUM_
+ *  The enum to use for \c zk::async launch policy. This should be highly related to \c ZKPP_FUTURE_TEMPLATE and usually mapped
+ *  to std::launch::async or boost::launch::async.
+ *
  *  \def ZKPP_FUTURE_INCLUDE
  *  The file to include to get the implementation for \c future and \c promise. If you define \c ZKPP_FUTURE_TEMPLATE
  *  and \c ZKPP_PROMISE_TEMPLATE, you must also define this.
@@ -60,10 +68,14 @@
 #   define ZKPP_FUTURE_INCLUDE   <future>
 #   define ZKPP_FUTURE_TEMPLATE  std::future
 #   define ZKPP_PROMISE_TEMPLATE std::promise
+#   define ZKPP_ASYNC_TEMPLATE   std::async
+#   define ZKPP_LAUNCH_ENUM      std::launch
 #elif ZKPP_FUTURE_USE_STD_EXPERIMENTAL
 #   define ZKPP_FUTURE_INCLUDE   <experimental/future>
 #   define ZKPP_FUTURE_TEMPLATE  std::experimental::future
 #   define ZKPP_PROMISE_TEMPLATE std::experimental::promise
+#   define ZKPP_ASYNC_TEMPLATE   std::async
+#   define ZKPP_LAUNCH_ENUM      std::launch
 #elif ZKPP_FUTURE_USE_BOOST
 #   define BOOST_THREAD_PROVIDES_FUTURE
 #   define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
@@ -71,6 +83,8 @@
 #   define ZKPP_FUTURE_INCLUDE   <boost/thread/future.hpp>
 #   define ZKPP_FUTURE_TEMPLATE  boost::future
 #   define ZKPP_PROMISE_TEMPLATE boost::promise
+#   define ZKPP_ASYNC_TEMPLATE   boost::async
+#   define ZKPP_LAUNCH_ENUM      boost::launch
 #elif ZKPP_FUTURE_USE_CUSTOM
 #   if !defined ZKPP_FUTURE_TEMPLATE || !defined ZKPP_PROMISE_TEMPLATE || !defined ZKPP_FUTURE_INCLUDE
 #       error "When ZKPP_FUTURE_USE_CUSTOM is set, you must also define ZKPP_FUTURE_TEMPLATE, ZKPP_PROMISE_TEMPLATE,"
@@ -96,6 +110,9 @@ using future = ZKPP_FUTURE_TEMPLATE<T>;
 
 template <typename T>
 using promise = ZKPP_PROMISE_TEMPLATE<T>;
+
+using ZKPP_LAUNCH_ENUM;
+using ZKPP_ASYNC_TEMPLATE;
 
 /** \} **/
 

--- a/src/zk/multi.cpp
+++ b/src/zk/multi.cpp
@@ -1,4 +1,5 @@
 #include "multi.hpp"
+#include "exceptions.hpp"
 
 #include <new>
 #include <ostream>
@@ -67,11 +68,11 @@ const T& op::as(ptr<const char> operation) const
     }
     catch (const std::bad_variant_access&)
     {
-        throw std::logic_error( std::string("Invalid op type for op::")
+        zk::throw_exception(std::logic_error( std::string("Invalid op type for op::")
                               + std::string(operation)
                               + std::string(": ")
                               + to_string(type())
-                              );
+                              ));
     }
 }
 
@@ -259,11 +260,11 @@ const T& multi_result::part::as(ptr<const char> operation) const
     }
     catch (const std::bad_variant_access&)
     {
-        throw std::logic_error( std::string("Invalid op type for multi_result::")
+        zk::throw_exception(std::logic_error( std::string("Invalid op type for multi_result::")
                               + std::string(operation)
                               + std::string(": ")
                               + to_string(type())
-                              );
+                              ));
     }
 }
 

--- a/src/zk/multi.hpp
+++ b/src/zk/multi.hpp
@@ -292,6 +292,9 @@ public:
 
     multi_result(std::vector<part> parts) noexcept;
 
+    multi_result(multi_result&&) = default;
+    multi_result & operator=(multi_result&&) = default;
+
     ~multi_result() noexcept;
 
     /// The number of results in this transaction bundle.

--- a/src/zk/results.hpp
+++ b/src/zk/results.hpp
@@ -227,6 +227,8 @@ public:
     explicit watch_result(get_result initial, future<event> next) noexcept;
 
     watch_result(watch_result&&) = default;
+    watch_result& operator=(watch_result&&) = default;
+
 
     ~watch_result() noexcept;
 
@@ -260,6 +262,8 @@ public:
     explicit watch_children_result(get_children_result initial, future<event> next) noexcept;
 
     watch_children_result(watch_children_result&&) = default;
+    watch_children_result& operator=(watch_children_result&&) = default;
+
 
     ~watch_children_result() noexcept;
 
@@ -293,6 +297,7 @@ public:
     explicit watch_exists_result(exists_result initial, future<event> next) noexcept;
 
     watch_exists_result(watch_exists_result&&) = default;
+    watch_exists_result & operator=(watch_exists_result&&) = default;
 
     ~watch_exists_result() noexcept;
 


### PR DESCRIPTION
Hey,

So we would like to use `boost::future` also therefore I made this implementation. This might not be ideal solution, but it solves my problem.

Most of the 'not ideal solution' comes from the fact, that calling `boost::promise::set_exception()`  with `boost::current_exception()` requires that exception would be either thrown with `boost::throw_exception()` or wrapped in `boost::enable_current_exception(...)` (I tested on gcc 7 and without wrapping, exception rethrown was of wrong type). To work around this I added `zk::throw_exception()` wrapper which either throws directly for `std::future` case or does necessary wrapping when using `boost::future`.

Another problem was that `boost::enable_current_exception()`, requires derived exception types. Therefore I removed `final` declarations from error types. 

Also I introduced `zk::exception_ptr`, `zk::current_exception()` and `zk::async()` to map either to `std` variants or `boost` ones for compatability.



This most likely solves #108  and #107 