### PR TITLE
build: Use CMAKE_CURRENT_SOURCE_DIR to add CMake modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_policy(VERSION 3.5)
 cmake_policy(SET CMP0037 OLD) # allow generation of "test" target
 set(CMAKE_REQUIRED_QUIET YES) # tell check_include_file_cxx to keep quiet
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")
 
 include(BuildFunctions)
 include(CheckIncludeFileCXX)


### PR DESCRIPTION
Fixes #115