### PR TITLE
core: Mark most result types as default-movable and copyable

### DIFF
--- a/src/zk/acl.hpp
+++ b/src/zk/acl.hpp
@@ -29,21 +29,35 @@ enum class permission : unsigned int
     all     = 0b11111, //!< You can do anything.
 };
 
+/// \{
 /// Set union operation of \ref permission.
-constexpr permission operator|(permission a, permission b)
+inline constexpr permission operator|(permission a, permission b)
 {
     return permission(static_cast<unsigned int>(a) | static_cast<unsigned int>(b));
 }
 
+inline constexpr permission& operator|=(permission& self, permission mask)
+{
+    return self = self | mask;
+}
+/// \}
+
+/// \{
 /// Set intersection operation of \ref permission.
-constexpr permission operator&(permission a, permission b)
+inline constexpr permission operator&(permission a, permission b)
 {
     return permission(static_cast<unsigned int>(a) & static_cast<unsigned int>(b));
 }
 
+inline constexpr permission& operator&=(permission& self, permission mask)
+{
+    return self = self & mask;
+}
+/// \}
+
 /// Set inverse operation of \ref permission. This is not exactly the bitwise complement of \a a, as the returned value
 /// will only include bits set that are valid in \ref permission discriminants.
-constexpr permission operator~(permission a)
+inline constexpr permission operator~(permission a)
 {
     return permission(~static_cast<unsigned int>(a)) & permission::all;
 }
@@ -51,7 +65,7 @@ constexpr permission operator~(permission a)
 /// Check that \a self allows it \a perform all operations. For example,
 /// `allows(permission::read | permission::write, permission::read)` will be \c true, as `read|write` is allowed to
 /// \c read.
-constexpr bool allows(permission self, permission perform)
+inline constexpr bool allows(permission self, permission perform)
 {
     return (self & perform) == perform;
 }
@@ -70,6 +84,12 @@ class acl_rule final
 public:
     /// Create an ACL under the given \a scheme and \a id with the given \a permissions.
     acl_rule(std::string scheme, std::string id, permission permissions);
+
+    acl_rule(const acl_rule&)            = default;
+    acl_rule& operator=(const acl_rule&) = default;
+
+    acl_rule(acl_rule&&)            = default;
+    acl_rule& operator=(acl_rule&&) = default;
 
     ~acl_rule() noexcept;
 
@@ -154,6 +174,12 @@ public:
     acl(std::initializer_list<acl_rule> rules) :
             acl(std::vector<acl_rule>(rules))
     { }
+
+    acl(const acl&)            = default;
+    acl& operator=(const acl&) = default;
+
+    acl(acl&&)            = default;
+    acl& operator=(acl&&) = default;
 
     ~acl() noexcept;
 

--- a/src/zk/buffer.hpp
+++ b/src/zk/buffer.hpp
@@ -73,24 +73,27 @@ namespace zk
 /// | `buffer::value_type`  | `char`                    | Buffers must be made of single-byte elements                 |
 /// | `buffer::size_type`   | `std::size_t`             |                                                              |
 /// | `buffer(ib, ie)`      | `buffer`                  | Constructs a buffer with the range [`ib`, `ie`)              |
-/// | `buffer(buffer&&)`    | `buffer`                  | Move constructible.                                          |
+/// | `buffer(buffer&&)`    | `buffer`                  | Move constructible (must be `noexcept`).                     |
+/// | `operator=(buffer&&)` | `buffer&`                 | Move assignable (must be `noexcept`).                        |
 /// | `size()`              | `size_type`               | Get the length of the buffer                                 |
 /// | `data()`              | `const value_type*`       | Get a pointer to the beginning of the contents               |
 using buffer = ZKPP_BUFFER_TYPE;
 
 // Check through static_assert:
-static_assert(sizeof(buffer::value_type) == 1, "buffer::value_type must be single-byte elements");
+static_assert(sizeof(buffer::value_type) == 1U, "buffer::value_type must be single-byte elements");
 static_assert(std::is_same<std::size_t, buffer::size_type>::value, "buffer::size_type must be std::size_t");
 static_assert(std::is_constructible<buffer, ptr<const buffer::value_type>, ptr<const buffer::value_type>>::value,
               "buffer must be constructible with two pointers"
              );
 static_assert(std::is_move_constructible<buffer>::value, "buffer must be move-constructible");
+static_assert(std::is_nothrow_move_constructible<buffer>::value, "buffer must be nothrow move-constructible");
+static_assert(std::is_nothrow_move_assignable<buffer>::value, "buffer must be nothrow move-assignable");
 static_assert(std::is_same<decltype(std::declval<const buffer&>().size()), buffer::size_type>::value,
               "buffer::size() must return buffer::size_type"
              );
 static_assert(std::is_constructible<ptr<const buffer::value_type>,
-                                   decltype(std::declval<const buffer&>().data())
-                                  >::value,
+                                    decltype(std::declval<const buffer&>().data())
+                                   >::value,
               "buffer::data() must return ptr<const buffer::value_type>"
              );
 

--- a/src/zk/results.cpp
+++ b/src/zk/results.cpp
@@ -81,6 +81,11 @@ std::string to_string(const get_result& self)
     return to_string_generic(self);
 }
 
+static_assert(std::is_copy_constructible_v<get_result>);
+static_assert(std::is_copy_assignable_v<get_result>);
+static_assert(std::is_nothrow_move_constructible_v<get_result>);
+static_assert(std::is_nothrow_move_assignable_v<get_result>);
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // get_children_result                                                                                                //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -105,6 +110,11 @@ std::string to_string(const get_children_result& self)
 {
     return to_string_generic(self);
 }
+
+static_assert(std::is_copy_constructible_v<get_children_result>);
+static_assert(std::is_copy_assignable_v<get_children_result>);
+static_assert(std::is_nothrow_move_constructible_v<get_children_result>);
+static_assert(std::is_nothrow_move_assignable_v<get_children_result>);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // exists_result                                                                                                      //
@@ -132,6 +142,11 @@ std::string to_string(const exists_result& self)
     return to_string_generic(self);
 }
 
+static_assert(std::is_copy_constructible_v<exists_result>);
+static_assert(std::is_copy_assignable_v<exists_result>);
+static_assert(std::is_nothrow_move_constructible_v<exists_result>);
+static_assert(std::is_nothrow_move_assignable_v<exists_result>);
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // create_result                                                                                                      //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -153,6 +168,11 @@ std::string to_string(const create_result& self)
     return to_string_generic(self);
 }
 
+static_assert(std::is_copy_constructible_v<create_result>);
+static_assert(std::is_copy_assignable_v<create_result>);
+static_assert(std::is_nothrow_move_constructible_v<create_result>);
+static_assert(std::is_nothrow_move_assignable_v<create_result>);
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // set_result                                                                                                         //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -173,6 +193,11 @@ std::string to_string(const set_result& self)
 {
     return to_string_generic(self);
 }
+
+static_assert(std::is_copy_constructible_v<set_result>);
+static_assert(std::is_copy_assignable_v<set_result>);
+static_assert(std::is_nothrow_move_constructible_v<set_result>);
+static_assert(std::is_nothrow_move_assignable_v<set_result>);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // get_acl_result                                                                                                     //
@@ -196,6 +221,11 @@ std::string to_string(const get_acl_result& self)
     return to_string_generic(self);
 }
 
+static_assert(std::is_copy_constructible_v<get_acl_result>);
+static_assert(std::is_copy_assignable_v<get_acl_result>);
+static_assert(std::is_nothrow_move_constructible_v<get_acl_result>);
+static_assert(std::is_nothrow_move_assignable_v<get_acl_result>);
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // event                                                                                                              //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -214,6 +244,11 @@ std::string to_string(const event& self)
 {
     return to_string_generic(self);
 }
+
+static_assert(std::is_copy_constructible_v<event>);
+static_assert(std::is_copy_assignable_v<event>);
+static_assert(std::is_nothrow_move_constructible_v<event>);
+static_assert(std::is_nothrow_move_assignable_v<event>);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // watch_result                                                                                                       //
@@ -237,6 +272,9 @@ std::string to_string(const watch_result& self)
     return to_string_generic(self);
 }
 
+static_assert(std::is_nothrow_move_constructible_v<watch_result>);
+static_assert(std::is_nothrow_move_assignable_v<watch_result>);
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // watch_children_result                                                                                              //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -259,6 +297,9 @@ std::string to_string(const watch_children_result& self)
     return to_string_generic(self);
 }
 
+static_assert(std::is_nothrow_move_constructible_v<watch_children_result>);
+static_assert(std::is_nothrow_move_assignable_v<watch_children_result>);
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // watch_exists_result                                                                                                //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -280,5 +321,8 @@ std::string to_string(const watch_exists_result& self)
 {
     return to_string_generic(self);
 }
+
+static_assert(std::is_nothrow_move_constructible_v<watch_exists_result>);
+static_assert(std::is_nothrow_move_assignable_v<watch_exists_result>);
 
 }

--- a/src/zk/results.hpp
+++ b/src/zk/results.hpp
@@ -26,6 +26,12 @@ class get_result final
 public:
     explicit get_result(buffer data, const zk::stat& stat) noexcept;
 
+    get_result(const get_result&)            = default;
+    get_result& operator=(const get_result&) = default;
+
+    get_result(get_result&&)            = default;
+    get_result& operator=(get_result&&) = default;
+
     ~get_result() noexcept;
 
     /// \{
@@ -60,6 +66,12 @@ public:
 public:
     explicit get_children_result(children_list_type children, const stat& parent_stat) noexcept;
 
+    get_children_result(const get_children_result&)            = default;
+    get_children_result& operator=(const get_children_result&) = default;
+
+    get_children_result(get_children_result&&)            = default;
+    get_children_result& operator=(get_children_result&&) = default;
+
     ~get_children_result() noexcept;
 
     /// \{
@@ -90,6 +102,12 @@ class exists_result final
 public:
     explicit exists_result(const optional<zk::stat>& stat) noexcept;
 
+    exists_result(const exists_result&)            = default;
+    exists_result& operator=(const exists_result&) = default;
+
+    exists_result(exists_result&&)            = default;
+    exists_result& operator=(exists_result&&) = default;
+
     ~exists_result() noexcept;
 
     /// \{
@@ -118,6 +136,12 @@ class create_result final
 public:
     explicit create_result(std::string name) noexcept;
 
+    create_result(const create_result&)            = default;
+    create_result& operator=(const create_result&) = default;
+
+    create_result(create_result&&)            = default;
+    create_result& operator=(create_result&&) = default;
+
     ~create_result() noexcept;
 
     /// \{
@@ -143,6 +167,12 @@ class set_result final
 public:
     explicit set_result(const zk::stat& stat) noexcept;
 
+    set_result(const set_result&)            = default;
+    set_result& operator=(const set_result&) = default;
+
+    set_result(set_result&&)            = default;
+    set_result& operator=(set_result&&) = default;
+
     ~set_result() noexcept;
 
     /// \{
@@ -165,7 +195,13 @@ class get_acl_result final
 public:
     explicit get_acl_result(zk::acl acl, const zk::stat& stat) noexcept;
 
-    virtual ~get_acl_result() noexcept;
+    get_acl_result(const get_acl_result&)            = default;
+    get_acl_result& operator=(const get_acl_result&) = default;
+
+    get_acl_result(get_acl_result&&)            = default;
+    get_acl_result& operator=(get_acl_result&&) = default;
+
+    ~get_acl_result() noexcept;
 
     /// \{
     /// The \ref zk::acl of the entry.
@@ -204,6 +240,12 @@ class event final
 public:
     explicit event(event_type type, zk::state state) noexcept;
 
+    event(const event&)            = default;
+    event& operator=(const event&) = default;
+
+    event(event&&)            = default;
+    event& operator=(event&&) = default;
+
     /// The type of event that occurred.
     const event_type& type() const { return _type; }
 
@@ -226,9 +268,11 @@ class watch_result final
 public:
     explicit watch_result(get_result initial, future<event> next) noexcept;
 
-    watch_result(watch_result&&) = default;
-    watch_result& operator=(watch_result&&) = default;
+    watch_result(const watch_result&)            = delete;
+    watch_result& operator=(const watch_result&) = delete;
 
+    watch_result(watch_result&&)            = default;
+    watch_result& operator=(watch_result&&) = default;
 
     ~watch_result() noexcept;
 
@@ -261,9 +305,11 @@ class watch_children_result final
 public:
     explicit watch_children_result(get_children_result initial, future<event> next) noexcept;
 
-    watch_children_result(watch_children_result&&) = default;
-    watch_children_result& operator=(watch_children_result&&) = default;
+    watch_children_result(const watch_children_result&)            = delete;
+    watch_children_result& operator=(const watch_children_result&) = delete;
 
+    watch_children_result(watch_children_result&&)            = default;
+    watch_children_result& operator=(watch_children_result&&) = default;
 
     ~watch_children_result() noexcept;
 
@@ -296,8 +342,11 @@ class watch_exists_result final
 public:
     explicit watch_exists_result(exists_result initial, future<event> next) noexcept;
 
-    watch_exists_result(watch_exists_result&&) = default;
-    watch_exists_result & operator=(watch_exists_result&&) = default;
+    watch_exists_result(const watch_exists_result&)            = delete;
+    watch_exists_result& operator=(const watch_exists_result&) = delete;
+
+    watch_exists_result(watch_exists_result&&)            = default;
+    watch_exists_result& operator=(watch_exists_result&&) = default;
 
     ~watch_exists_result() noexcept;
 


### PR DESCRIPTION
This change explicitly marks most of the move- and copy- constructors
and assignment operators as `= default`. This makes them nothrow by
default definition, which is enforced with `static_assert`s on the
types.

Fixes issue #123